### PR TITLE
Expand WebGL demo with collectibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # games
 Computer games developed by GPTs and other LLMs.
+
+## Projects
+
+- [New 3D WebGL Game](webgl-game/README.md) – prototype using Three.js featuring a jumping cube, coin collectibles and basic scoring.

--- a/webgl-game/README.md
+++ b/webgl-game/README.md
@@ -1,0 +1,26 @@
+# New 3D WebGL Game
+
+This folder contains an early prototype of a new 3D WebGL game built with [Three.js](https://threejs.org/). The prototype now features a movable cube character with jumping, a ground plane, basic lighting and a simple collectible system with scoring.
+
+## Architecture
+
+- `index.html` sets up the page and loads the main module.
+- `src/main.js` bootstraps the `Game` class, which sets up the Three.js scene, camera, renderer and game loop.
+- `src/environment.js` adds a simple ground plane and ambient lighting.
+- `src/player.js` defines a `Player` class that renders a cube and supports arrow key movement and jumping with the space bar.
+- `src/collectible.js` implements a `Collectible` class used to spawn coins that can be picked up for points.
+- `index.html` displays the current score in a fixed overlay.
+
+The project uses ES modules and loads dependencies from public CDNs so there is no local build step required.
+
+## Running
+
+Open `index.html` in a modern browser with WebGL support. Use the arrow keys to move the cube on the ground plane, press the space bar to jump and collect the floating coins to increase your score.
+
+## Next Steps
+
+- Add obstacles and more varied collectibles to enrich gameplay.
+- Improve collision detection and physics (consider integrating a physics engine).
+- Create level layouts, objectives and win conditions.
+- Expand the UI with health/lives indicators and a start menu.
+- Explore using a bundler and local asset pipeline as the project grows.

--- a/webgl-game/index.html
+++ b/webgl-game/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>New 3D WebGL Game</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    canvas { display: block; }
+    #score {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      color: white;
+      font-family: monospace;
+      z-index: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="score">Score: 0</div>
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/webgl-game/src/collectible.js
+++ b/webgl-game/src/collectible.js
@@ -1,0 +1,20 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class Collectible {
+  constructor(scene, position = new THREE.Vector3()) {
+    this.scene = scene;
+    const geometry = new THREE.SphereGeometry(0.3, 16, 16);
+    const material = new THREE.MeshStandardMaterial({ color: 0xffcc00 });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.position.copy(position);
+    this.scene.add(this.mesh);
+    this.collected = false;
+  }
+
+  collect() {
+    if (!this.collected) {
+      this.scene.remove(this.mesh);
+      this.collected = true;
+    }
+  }
+}

--- a/webgl-game/src/environment.js
+++ b/webgl-game/src/environment.js
@@ -1,0 +1,23 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class Environment {
+  constructor(scene) {
+    this.scene = scene;
+    this.createGround();
+    this.addLighting();
+  }
+
+  createGround() {
+    const geometry = new THREE.PlaneGeometry(50, 50);
+    const material = new THREE.MeshStandardMaterial({ color: 0x808080 });
+    const plane = new THREE.Mesh(geometry, material);
+    plane.rotation.x = -Math.PI / 2;
+    plane.receiveShadow = true;
+    this.scene.add(plane);
+  }
+
+  addLighting() {
+    const ambient = new THREE.AmbientLight(0x404040);
+    this.scene.add(ambient);
+  }
+}

--- a/webgl-game/src/main.js
+++ b/webgl-game/src/main.js
@@ -1,0 +1,77 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+import { Player } from './player.js';
+import { Environment } from './environment.js';
+import { Collectible } from './collectible.js';
+
+class Game {
+  constructor() {
+    this.clock = new THREE.Clock();
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x222222);
+    this.camera = new THREE.PerspectiveCamera(
+      75,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      1000
+    );
+    this.camera.position.set(0, 2, 5);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(this.renderer.domElement);
+
+    window.addEventListener('resize', () => this.onResize());
+
+    this.environment = new Environment(this.scene);
+    this.player = new Player(this.scene);
+    this.collectibles = [];
+    this.score = 0;
+    this.scoreEl = document.getElementById('score');
+    this.spawnCollectibles(5);
+
+    this.animate = this.animate.bind(this);
+    this.animate();
+  }
+
+  spawnCollectibles(count) {
+    for (let i = 0; i < count; i++) {
+      const pos = new THREE.Vector3(
+        (Math.random() - 0.5) * 20,
+        0.5,
+        (Math.random() - 0.5) * 20
+      );
+      this.collectibles.push(new Collectible(this.scene, pos));
+    }
+  }
+
+  onResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  animate() {
+    requestAnimationFrame(this.animate);
+    const delta = this.clock.getDelta();
+    this.player.update(delta);
+    this.checkCollisions();
+    if (this.scoreEl) {
+      this.scoreEl.textContent = `Score: ${this.score}`;
+    }
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  checkCollisions() {
+    const playerPos = this.player.mesh.position;
+    this.collectibles.forEach((c) => {
+      if (!c.collected && c.mesh.position.distanceTo(playerPos) < 0.7) {
+        c.collect();
+        this.score += 1;
+      }
+    });
+    this.collectibles = this.collectibles.filter((c) => !c.collected);
+  }
+}
+
+new Game();

--- a/webgl-game/src/player.js
+++ b/webgl-game/src/player.js
@@ -1,0 +1,50 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class Player {
+  constructor(scene) {
+    this.scene = scene;
+    this.mesh = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      new THREE.MeshStandardMaterial({ color: 0x44aa88 })
+    );
+    this.mesh.position.y = 0.5;
+    scene.add(this.mesh);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 7.5);
+    scene.add(light);
+
+    this.velocity = new THREE.Vector3();
+    this.speed = 2;
+    this.jumpSpeed = 5;
+    this.onGround = true;
+    this.keys = {};
+    window.addEventListener('keydown', (e) => (this.keys[e.code] = true));
+    window.addEventListener('keyup', (e) => (this.keys[e.code] = false));
+  }
+
+  update(delta) {
+    this.velocity.x = 0;
+    this.velocity.z = 0;
+    if (this.keys['ArrowLeft']) this.velocity.x -= this.speed * delta;
+    if (this.keys['ArrowRight']) this.velocity.x += this.speed * delta;
+    if (this.keys['ArrowUp']) this.velocity.z -= this.speed * delta;
+    if (this.keys['ArrowDown']) this.velocity.z += this.speed * delta;
+
+    if (this.keys['Space'] && this.onGround) {
+      this.velocity.y = this.jumpSpeed;
+      this.onGround = false;
+    }
+
+    // apply gravity
+    this.velocity.y -= 9.8 * delta;
+
+    this.mesh.position.add(this.velocity);
+
+    if (this.mesh.position.y <= 0.5) {
+      this.mesh.position.y = 0.5;
+      this.velocity.y = 0;
+      this.onGround = true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add coin collectibles and score overlay
- track collisions and update score in the main loop
- document new gameplay features and architecture updates

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684037353f348320a0bc9c07c338bcad