### PR TITLE
Add pickups and scoring system

### DIFF
--- a/webgl-game/DEVLOG.md
+++ b/webgl-game/DEVLOG.md
@@ -8,21 +8,23 @@ This document summarizes the progress of the WebGL game.
 - Ground plane and ambient lighting.
 - Two obstacle cubes added to the scene.
 - Basic collision detection preventing the player from passing through obstacles.
+- Collectible pickups that update an on-screen score when collected.
 
 ## Changes in This Iteration
-- Introduced `Obstacle` class and created two obstacles via `Environment`.
-- Added collision detection logic in `Player`.
-- Updated `main.js` to pass obstacles to the player.
-- Expanded documentation and created `WORKFLOW.md` describing the development workflow.
+- Added `Pickup` class with spherical collectibles.
+- Environment now spawns three pickups.
+- Player checks for pickup collisions and updates a score display.
+- Game creates a score HUD element and passes it to the player.
 
 ## Remaining Work
 - Improve physics for smoother movement and jumping.
-- Add pickups, scoring and level progression.
+- Add more obstacle variety and refine models.
+- Begin implementing level progression and objectives.
 - Consider bundling assets locally instead of loading from CDNs.
 
 ## Next Developer Steps
-1. Add collectible items and track a score.
-2. Polish obstacle models and add more variety.
-3. Begin implementing level progression and simple objectives.
-4. Review and refine physics to feel more natural.
+1. Polish pickup visuals and add sound effects on collection.
+2. Introduce multiple levels with increasing difficulty.
+3. Review and refine physics to feel more natural.
+4. Investigate bundling assets and managing dependencies locally.
 

--- a/webgl-game/README.md
+++ b/webgl-game/README.md
@@ -5,6 +5,7 @@ This folder contains an early prototype of a new 3D WebGL game built with [Three
 - A ground plane and ambient lighting.
 - Two obstacle cubes positioned in the scene.
 - Basic collision detection so the player cannot pass through the obstacles.
+- Collectible pickups that increase a visible score when collected.
 
 ## Architecture
 

--- a/webgl-game/src/environment.js
+++ b/webgl-game/src/environment.js
@@ -1,13 +1,16 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
 import { Obstacle } from './obstacle.js';
+import { Pickup } from './pickup.js';
 
 export class Environment {
   constructor(scene) {
     this.scene = scene;
     this.obstacles = [];
+    this.pickups = [];
     this.createGround();
     this.addLighting();
     this.createObstacles();
+    this.createPickups();
   }
 
   createGround() {
@@ -28,5 +31,17 @@ export class Environment {
     const obstacle1 = new Obstacle(this.scene, new THREE.Vector3(3, 0.5, -2));
     const obstacle2 = new Obstacle(this.scene, new THREE.Vector3(-2, 0.5, 2));
     this.obstacles.push(obstacle1, obstacle2);
+  }
+
+  createPickups() {
+    const positions = [
+      new THREE.Vector3(2, 0.3, -3),
+      new THREE.Vector3(-3, 0.3, 1),
+      new THREE.Vector3(0, 0.3, 3),
+    ];
+    for (const pos of positions) {
+      const pickup = new Pickup(this.scene, pos);
+      this.pickups.push(pickup);
+    }
   }
 }

--- a/webgl-game/src/main.js
+++ b/webgl-game/src/main.js
@@ -20,11 +20,26 @@ class Game {
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     document.body.appendChild(this.renderer.domElement);
 
+    this.scoreElement = document.createElement('div');
+    this.scoreElement.id = 'score';
+    this.scoreElement.style.position = 'absolute';
+    this.scoreElement.style.top = '10px';
+    this.scoreElement.style.left = '10px';
+    this.scoreElement.style.color = 'white';
+    this.scoreElement.style.fontFamily = 'sans-serif';
+    this.scoreElement.textContent = 'Score: 0';
+    document.body.appendChild(this.scoreElement);
+
     window.addEventListener('resize', () => this.onResize());
 
     this.environment = new Environment(this.scene);
 
-    this.player = new Player(this.scene, this.environment.obstacles);
+    this.player = new Player(
+      this.scene,
+      this.environment.obstacles,
+      this.environment.pickups,
+      this.scoreElement
+    );
 
     this.animate = this.animate.bind(this);
     this.animate();

--- a/webgl-game/src/pickup.js
+++ b/webgl-game/src/pickup.js
@@ -1,0 +1,23 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class Pickup {
+  constructor(scene, position = new THREE.Vector3()) {
+    this.scene = scene;
+    const geometry = new THREE.SphereGeometry(0.3, 16, 16);
+    const material = new THREE.MeshStandardMaterial({ color: 0xffcc00 });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.position.copy(position);
+    this.mesh.castShadow = true;
+    scene.add(this.mesh);
+
+    this.box = new THREE.Box3().setFromObject(this.mesh);
+  }
+
+  update() {
+    this.box.setFromObject(this.mesh);
+  }
+
+  collect() {
+    this.scene.remove(this.mesh);
+  }
+}

--- a/webgl-game/src/player.js
+++ b/webgl-game/src/player.js
@@ -1,9 +1,12 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
 
 export class Player {
-  constructor(scene, obstacles = []) {
+  constructor(scene, obstacles = [], pickups = [], scoreElement = null) {
     this.scene = scene;
     this.obstacles = obstacles;
+    this.pickups = pickups;
+    this.scoreElement = scoreElement;
+    this.score = 0;
     this.mesh = new THREE.Mesh(
       new THREE.BoxGeometry(1, 1, 1),
       new THREE.MeshStandardMaterial({ color: 0x44aa88 })
@@ -45,6 +48,19 @@ export class Player {
     const previous = this.mesh.position.clone();
     this.mesh.position.add(this.velocity);
     this.box.setFromObject(this.mesh);
+
+    for (let i = this.pickups.length - 1; i >= 0; i--) {
+      const pickup = this.pickups[i];
+      pickup.update();
+      if (this.box.intersectsBox(pickup.box)) {
+        pickup.collect();
+        this.pickups.splice(i, 1);
+        this.score += 1;
+        if (this.scoreElement) {
+          this.scoreElement.textContent = `Score: ${this.score}`;
+        }
+      }
+    }
 
     for (const obstacle of this.obstacles) {
       obstacle.update();


### PR DESCRIPTION
## Summary
- create `Pickup` class for collectible objects
- spawn pickups via `Environment`
- update `Player` to detect pickups and update a score HUD
- display score HUD from `Game`
- document new feature and iteration progress

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840455a64fc83208723d58b1ae17f1e