### PR TITLE
Add health system and chaser enemy

### DIFF
--- a/webgl-game/DEVLOG.md
+++ b/webgl-game/DEVLOG.md
@@ -12,14 +12,17 @@ This document summarizes the progress of the WebGL game.
 - Three level structure with enemy objects and dynamic spawning.
 - On-screen HUD for score and level with transient story messages.
 - Levels randomly generate the layout of pickups, obstacles and enemies each playthrough.
+- Health system with three hearts and restart on death.
+- Green health pickups that restore one heart.
+- New chaser enemy type that pursues the player.
+- Four levels with an expanding storyline.
 
 ## Changes in This Iteration
-- Added a third level featuring a projectile-firing turret enemy.
-- Created new `Turret` and `Projectile` classes for ranged attacks.
-- Enemies now receive the player reference for targeted behaviors.
-- Player movement now uses acceleration and friction for smoother control.
-- Added sound effects for jumping, collecting pickups and enemy collisions.
-- The final victory message displays your total score.
+- Introduced a persistent health system displayed on the HUD.
+- Added green health pickups which heal the player.
+- Implemented a chaser enemy that actively pursues the player.
+- Created a new fourth level showcasing the chaser and health pickups.
+- Game now restarts from the beginning when all health is lost.
 
 ## Remaining Work
 - Polish projectile behavior and tweak turret balance.

--- a/webgl-game/README.md
+++ b/webgl-game/README.md
@@ -5,12 +5,14 @@ This folder contains a prototype 3D WebGL game built with [Three.js](https://thr
 - Ground plane and ambient lighting.
 - Static obstacle cubes that block movement.
 - Collectible pickups that update an on-screen score.
-- A three level structure with an expanding storyline.
+- A four level structure with an expanding storyline.
 - Dynamic placement of pickups, obstacles and enemies each time you play.
 - Moving enemy spheres on later levels that reset the player on contact.
 - A turret enemy that fires projectiles on the final stage.
+- A chaser enemy introduced in level four.
+- Health system with heart pickups and game over state.
 - Sound effects for jumping, pickups and getting hit.
-- On-screen HUD elements for the score, current level and story messages.
+- On-screen HUD elements for the score, health, current level and story messages.
 
 ## Architecture
 

--- a/webgl-game/src/chaser.js
+++ b/webgl-game/src/chaser.js
@@ -1,0 +1,27 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class Chaser {
+  constructor(scene, position = new THREE.Vector3(), speed = 1.5) {
+    this.scene = scene;
+    this.speed = speed;
+    this.mesh = new THREE.Mesh(
+      new THREE.SphereGeometry(0.4, 16, 16),
+      new THREE.MeshStandardMaterial({ color: 0xff66ff })
+    );
+    this.mesh.position.copy(position);
+    scene.add(this.mesh);
+    this.box = new THREE.Box3().setFromObject(this.mesh);
+  }
+
+  update(delta, player) {
+    if (player) {
+      const dir = new THREE.Vector3().subVectors(player.mesh.position, this.mesh.position);
+      dir.y = 0;
+      if (dir.lengthSq() > 0.001) {
+        dir.normalize();
+        this.mesh.position.addScaledVector(dir, this.speed * delta);
+      }
+    }
+    this.box.setFromObject(this.mesh);
+  }
+}

--- a/webgl-game/src/environment.js
+++ b/webgl-game/src/environment.js
@@ -3,6 +3,8 @@ import { Obstacle } from './obstacle.js';
 import { Pickup } from './pickup.js';
 import { Enemy } from './enemy.js';
 import { Turret } from './turret.js';
+import { Chaser } from './chaser.js';
+import { HealthPickup } from './healthPickup.js';
 
 export class Environment {
   constructor(scene) {
@@ -10,6 +12,7 @@ export class Environment {
     this.player = null;
     this.obstacles = [];
     this.pickups = [];
+    this.healthPickups = [];
     this.enemies = [];
     this.createGround();
     this.addLighting();
@@ -52,6 +55,13 @@ export class Environment {
     this.pickups = [];
   }
 
+  clearHealthPickups() {
+    for (const p of this.healthPickups) {
+      this.scene.remove(p.mesh);
+    }
+    this.healthPickups = [];
+  }
+
   clearEnemies() {
     for (const e of this.enemies) {
       if (e.mesh) this.scene.remove(e.mesh);
@@ -75,12 +85,23 @@ export class Environment {
     }
   }
 
+  createHealthPickups(positions = []) {
+    this.clearHealthPickups();
+    for (const pos of positions) {
+      const hp = new HealthPickup(this.scene, pos);
+      this.healthPickups.push(hp);
+    }
+  }
+
   createEnemies(configs = []) {
     this.clearEnemies();
     for (const cfg of configs) {
       if (cfg.type === 'turret') {
         const turret = new Turret(this.scene, cfg.position, cfg.interval, cfg.projectileSpeed, this);
         this.enemies.push(turret);
+      } else if (cfg.type === 'chaser') {
+        const chaser = new Chaser(this.scene, cfg.position, cfg.speed);
+        this.enemies.push(chaser);
       } else {
         const enemy = new Enemy(this.scene, cfg.position, cfg.axis, cfg.range, cfg.speed);
         this.enemies.push(enemy);

--- a/webgl-game/src/healthPickup.js
+++ b/webgl-game/src/healthPickup.js
@@ -1,0 +1,22 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export class HealthPickup {
+  constructor(scene, position = new THREE.Vector3()) {
+    this.scene = scene;
+    const geometry = new THREE.BoxGeometry(0.4, 0.4, 0.4);
+    const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.position.copy(position);
+    this.mesh.castShadow = true;
+    scene.add(this.mesh);
+    this.box = new THREE.Box3().setFromObject(this.mesh);
+  }
+
+  update() {
+    this.box.setFromObject(this.mesh);
+  }
+
+  collect() {
+    this.scene.remove(this.mesh);
+  }
+}

--- a/webgl-game/src/levels.js
+++ b/webgl-game/src/levels.js
@@ -32,6 +32,15 @@ export const LEVEL_GENERATORS = [
       { type: 'turret', position: new THREE.Vector3(0, 0.4, 0), interval: 2, projectileSpeed: 6 }
     ],
   }),
+  () => ({
+    message: 'Level 4: A stalker hunts you. Grab the green cube for health!',
+    pickups: [randomVector(0.3), randomVector(0.3), randomVector(0.3)],
+    healthPickups: [randomVector(0.3)],
+    obstacles: [randomVector(0.5), randomVector(0.5), randomVector(0.5)],
+    enemies: [
+      { type: 'chaser', position: randomVector(0.5), speed: 1.8 },
+    ],
+  }),
 ];
 
 export const LEVEL_COUNT = LEVEL_GENERATORS.length;

--- a/webgl-game/src/main.js
+++ b/webgl-game/src/main.js
@@ -32,6 +32,15 @@ class Game {
     this.scoreElement.textContent = 'Score: 0';
     document.body.appendChild(this.scoreElement);
 
+    this.healthElement = document.createElement('div');
+    this.healthElement.id = 'health';
+    this.healthElement.style.position = 'absolute';
+    this.healthElement.style.top = '40px';
+    this.healthElement.style.left = '10px';
+    this.healthElement.style.color = 'white';
+    this.healthElement.style.fontFamily = 'sans-serif';
+    document.body.appendChild(this.healthElement);
+
     this.levelElement = document.createElement('div');
     this.levelElement.id = 'level';
     this.levelElement.style.position = 'absolute';
@@ -65,8 +74,11 @@ class Game {
       this.environment.obstacles,
       this.environment.pickups,
       this.environment.enemies,
+      this.environment.healthPickups,
       this.scoreElement,
-      (msg) => this.showMessage(msg, 2)
+      this.healthElement,
+      (msg) => this.showMessage(msg, 2),
+      () => this.restartGame()
     );
 
     this.environment.setPlayer(this.player);
@@ -88,6 +100,7 @@ class Game {
     const data = generateLevel(index);
     this.environment.createObstacles(data.obstacles);
     this.environment.createPickups(data.pickups);
+    this.environment.createHealthPickups(data.healthPickups || []);
     this.environment.createEnemies(data.enemies);
     this.levelElement.textContent = `Level: ${index + 1}`;
     this.showMessage(data.message, 4);
@@ -104,6 +117,22 @@ class Game {
     this.player.obstacles = this.environment.obstacles;
     this.player.pickups = this.environment.pickups;
     this.player.enemies = this.environment.enemies;
+    this.player.healthPickups = this.environment.healthPickups;
+    this.player.reset();
+  }
+
+  restartGame() {
+    this.showMessage('Game over! Restarting...', 3);
+    this.currentLevel = 0;
+    this.player.score = 0;
+    if (this.scoreElement) this.scoreElement.textContent = 'Score: 0';
+    this.loadLevel(this.currentLevel);
+    this.player.obstacles = this.environment.obstacles;
+    this.player.pickups = this.environment.pickups;
+    this.player.enemies = this.environment.enemies;
+    this.player.healthPickups = this.environment.healthPickups;
+    this.player.health = this.player.maxHealth;
+    if (this.healthElement) this.healthElement.textContent = `Health: ${this.player.health}`;
     this.player.reset();
   }
 


### PR DESCRIPTION
## Summary
- implement health pickups and chaser enemy classes
- extend environment to manage health pickups and chaser spawning
- update player with health system and damage/heal logic
- display health HUD and restart game on death
- add new level featuring chaser and medkit
- document progress and new mechanics

## Testing
- `node --check webgl-game/src/chaser.js`
- `node --check webgl-game/src/healthPickup.js`
- `node --check webgl-game/src/environment.js`
- `node --check webgl-game/src/player.js`
- `node --check webgl-game/src/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404e43886483208aa3d932600889d9